### PR TITLE
Add target framework version to project/solution dependencies output for c# projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test-results/
 /csproj.pssproj.user
 /npm-debug.log
 /csproj.sln.DotSettings.user
+*.user

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,3 @@ csproj.sln.DotSettings.user
 *.user
 test/debug.ps1
 env.cmd
-env.cmd
-env.cmd

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ csproj.sln.DotSettings.user
 /npm-debug.log
 /csproj.sln.DotSettings.user
 *.user
+test/debug.ps1
+env.cmd
+env.cmd
+env.cmd

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ obj/
 bin/
 test-results/
 .tools/
+csproj.pssproj.user
+csproj.sln.DotSettings.user
+.vs/csproj/v14/.suo
+.vs/csproj/v16/.suo

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ obj/
 bin/
 test-results/
 .tools/
+*.suo
+/csproj.pssproj.user
+/npm-debug.log
+/csproj.sln.DotSettings.user

--- a/csproj.pssproj
+++ b/csproj.pssproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Folder Include="src\" />
     <Folder Include="src\csproj\" />
+    <Folder Include="src\csproj\commandline\" />
     <Folder Include="src\csproj\functions\" />
     <Folder Include="test\" />
     <Folder Include="test\features\" />
@@ -92,6 +93,7 @@
     <Folder Include="test\input\test\src\Core\Core.Library2\Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="src\csproj\commandline\commandlines.ps1" />
     <Compile Include="src\csproj\csproj.psd1" />
     <Compile Include="src\csproj\Csproj.psm1" />
     <Compile Include="src\csproj\functions\assemblyinfo-utils.ps1" />
@@ -101,6 +103,7 @@
     <Compile Include="src\csproj\functions\nuget-utils.ps1" />
     <Compile Include="src\csproj\functions\packagesconfig-utils.ps1" />
     <Compile Include="src\csproj\functions\sln-utils.ps1" />
+    <Compile Include="src\csproj\functions\sln-verification.ps1" />
     <Compile Include="test\csproj-manipulations.tests.ps1" />
     <Compile Include="test\csproj-parsing.tests.ps1" />
     <Compile Include="test\features\referenceconvertion.feature.tests.ps1" />

--- a/csproj.pssproj
+++ b/csproj.pssproj
@@ -96,8 +96,6 @@
     <Compile Include="src\csproj\commandline\commandlines.ps1" />
     <Compile Include="src\csproj\csproj.psd1" />
     <Compile Include="src\csproj\Csproj.psm1" />
-    <Compile Include="src\csproj\functions\assemblyinfo-utils.ps1" />
-    <Compile Include="src\csproj\functions\choco-utils.ps1" />
     <Compile Include="src\csproj\functions\conversion.ps1" />
     <Compile Include="src\csproj\functions\csproj-utils.ps1" />
     <Compile Include="src\csproj\functions\nuget-utils.ps1" />

--- a/src/csproj/commandline/commandlines.ps1
+++ b/src/csproj/commandline/commandlines.ps1
@@ -1,0 +1,13 @@
+#
+# get_projdeps.ps1
+#
+function get-csprojdeps
+{
+	[CmdletBinding()]
+	param 
+	(
+		[parameter(Mandatory=$true)]
+		[string] $path
+	)
+	return get-csprojdependencies (Get-Item $path).FullName
+}

--- a/src/csproj/csproj.psm1
+++ b/src/csproj/csproj.psm1
@@ -16,6 +16,9 @@ get-childitem "$helpersPath\scan" -filter "*.ps1" |
     ? { -not ($_.Name.Contains(".Tests.")) } |
     % { . $_.FullName }
 
+get-childitem "$helpersPath\commandline" -filter "*.ps1" | 
+    ? { -not ($_.Name.Contains(".Tests.")) } |
+    % { . $_.FullName }
 
 #Export-ModuleMember -Function *
 Export-ModuleMember -function `
@@ -30,5 +33,6 @@ Export-ModuleMember -function `
     convert-packagestoprojectjson, repair-ProjectJSonProjectReferences, `
     initialize-projects, push-nugets, use-projects, `
     Copy-BindingRedirects, `
-    update-referencesToStable, find-unstablePackages `
+    update-referencesToStable, find-unstablePackages, `
+	get-csprojdeps `
     -Alias *

--- a/src/csproj/functions/csproj-utils.ps1
+++ b/src/csproj/functions/csproj-utils.ps1
@@ -57,6 +57,7 @@ public class ReferenceMeta {
     public string Path {get;set;}
     public bool? IsValid {get;set;}
     public string TargetFw {get; set;}
+    public string ResolvedPath {get; set;}
     
     public override string ToString() {
         return string.Format("-> {1}{0}", ShortName, IsValid != null ? ((IsValid.Value ? "[+]" : "[-]") + " ") : "");
@@ -185,6 +186,7 @@ param(
             Path = $path
             IsValid = $isvalid
             TargetFw = $csproj.TargetFw
+            ResolvedPath = Resolve-Path $abspath
         }
     }
 }
@@ -203,6 +205,7 @@ function get-referencenodes([Parameter(ValueFromPipeline=$true)][xml] $xml, $nod
 }
 
 function get-projectreferences([Parameter(ValueFromPipeline=$true, Mandatory=$true)][csproj] $csproj) {
+    Write-Host "> Getting Project References for: " $csproj.Path
     return get-referencenodes $csproj.xml "ProjectReference"  -csproj $csproj
 }
 

--- a/src/csproj/functions/csproj-utils.ps1
+++ b/src/csproj/functions/csproj-utils.ps1
@@ -186,7 +186,7 @@ param(
             Path = $path
             IsValid = $isvalid
             TargetFw = $csproj.TargetFw
-            ResolvedPath = Resolve-Path $abspath
+            ResolvedPath = Resolve-Path -ErrorAction  Continue -Path $abspath 
         }
     }
 }

--- a/src/csproj/functions/sln-verification.ps1
+++ b/src/csproj/functions/sln-verification.ps1
@@ -53,12 +53,12 @@ function get-slndependencies {
                         $version = $Matches["version"]
                     }
                 }
-                $props = [ordered]@{ project = $p.project; ref = $r; refType = $r.type; version = $version;  IsProjectValid = $true; targetFw = $targetFw; ReslovedPath = $resolvedPath }
+                $props = [ordered]@{ project = $p.project; projectTargetFw = $targetFw; ref = $r; refType = $r.type; version = $version;  IsProjectValid = $true; ReslovedPath = $resolvedPath }
                 $result += new-object -type pscustomobject -property $props 
             }
         } else {
             $isvalid = $true
-            $props = [ordered]@{ project = $p.project; ref = $null; refType = $null; version = $null; IsProjectValid = $isvalid; targetFw = ""; ReslovedPath = ""}
+            $props = [ordered]@{ project = $p.project; projectTargetFw = ""; ref = $null; refType = $null; version = $null; IsProjectValid = $isvalid; ReslovedPath = ""}
             $result += new-object -type pscustomobject -property $props 
         }
     }
@@ -409,7 +409,7 @@ function get-csprojdependencies {
     
     $refs = $refs | % {
         $r = $_
-        $props = [ordered]@{ ref = $r; refType = $r.type; path = $r.path; targetFw = $r.TargetFw }
+        $props = [ordered]@{ projectTargetFw = $csproj.TargetFw; ref = $r; refType = $r.type; path = $r.path; targetFw = $r.TargetFw }
         return new-object -type pscustomobject -property $props 
     }
     

--- a/src/csproj/functions/sln-verification.ps1
+++ b/src/csproj/functions/sln-verification.ps1
@@ -39,9 +39,11 @@ function get-slndependencies {
                 #$null = $r | add-property -name "Valid" -value $existsInSln
                 
                 $targetFw = ""
+                $resolvedPath = ""
                 if ($r.type -eq "project") {
                     $r.IsValid = $r.IsValid -and $existsInSln 
                     $targetFw = $p.csproj.TargetFw
+                    $resolvedPath = $r.ResolvedPath
                 }
                 
                 
@@ -51,12 +53,12 @@ function get-slndependencies {
                         $version = $Matches["version"]
                     }
                 }
-                $props = [ordered]@{ project = $p.project; ref = $r; refType = $r.type; version = $version;  IsProjectValid = $true; targetFw = $targetFw }
+                $props = [ordered]@{ project = $p.project; ref = $r; refType = $r.type; version = $version;  IsProjectValid = $true; targetFw = $targetFw; ReslovedPath = $resolvedPath }
                 $result += new-object -type pscustomobject -property $props 
             }
         } else {
             $isvalid = $true
-            $props = [ordered]@{ project = $p.project; ref = $null; refType = $null; version = $null; IsProjectValid = $isvalid; targetFw = ""; }
+            $props = [ordered]@{ project = $p.project; ref = $null; refType = $null; version = $null; IsProjectValid = $isvalid; targetFw = ""; ReslovedPath = ""}
             $result += new-object -type pscustomobject -property $props 
         }
     }

--- a/src/csproj/functions/sln-verification.ps1
+++ b/src/csproj/functions/sln-verification.ps1
@@ -37,22 +37,26 @@ function get-slndependencies {
                 $existsInSln = $slnproj -ne $null 
                 $exists = test-path $path
                 #$null = $r | add-property -name "Valid" -value $existsInSln
+                
+                $targetFw = ""
                 if ($r.type -eq "project") {
                     $r.IsValid = $r.IsValid -and $existsInSln 
+                    $targetFw = $p.csproj.TargetFw
                 }
+                
+                
                 $version = $null
                 if ($r.type -eq "nuget") {
                     if ($r.path -ne $null -and $r.path.replace("\","/") -match "/.*?(?<version>[0-9]+\.[0-9]+\.[0-9]+.*?)/") {                    
                         $version = $Matches["version"]
                     }
                 }
-                $props = [ordered]@{ project = $p.project; ref = $r; refType = $r.type; version = $version;  IsProjectValid = $true }
+                $props = [ordered]@{ project = $p.project; ref = $r; refType = $r.type; version = $version;  IsProjectValid = $true; targetFw = $targetFw }
                 $result += new-object -type pscustomobject -property $props 
             }
         } else {
             $isvalid = $true
-            if ($p.csproj -eq $null) { $isvalid = $false }
-            $props = [ordered]@{ project = $p.project; ref = $null; refType = $null; version = $null; IsProjectValid = $isvalid }
+            $props = [ordered]@{ project = $p.project; ref = $null; refType = $null; version = $null; IsProjectValid = $isvalid; targetFw = ""; }
             $result += new-object -type pscustomobject -property $props 
         }
     }
@@ -403,7 +407,7 @@ function get-csprojdependencies {
     
     $refs = $refs | % {
         $r = $_
-        $props = [ordered]@{ ref = $r; refType = $r.type; path = $r.path }
+        $props = [ordered]@{ ref = $r; refType = $r.type; path = $r.path; targetFw = $r.TargetFw }
         return new-object -type pscustomobject -property $props 
     }
     


### PR DESCRIPTION
Sometimes in a big solution, the target framework of a c# project may not be the same and can cause reference issues.  adding this to output may help.

![image](https://user-images.githubusercontent.com/575119/86132891-8e737680-bab5-11ea-96e7-ede18d86a5ed.png)

